### PR TITLE
Pass `save_payment_method` to actually attach to customer

### DIFF
--- a/without-webhooks/server/ruby/server.rb
+++ b/without-webhooks/server/ruby/server.rb
@@ -50,6 +50,9 @@ post '/pay' do
         # Create a Customer to store the PaymentMethod
         customer = Stripe::Customer.create
         payment_intent_data['customer'] = customer['id']
+        
+        # Set save_payment_method to true to attach the PM to the Customer
+        payment_intent_data['save_payment_method'] = True
 
         # setup_future_usage tells Stripe how you plan on using the saved card
         # set to 'off_session' if you plan on charging the saved card when the customer is not present


### PR DESCRIPTION
[Python code](https://github.com/stripe-samples/saving-card-after-payment/blob/d3c11542f008dbac9bebce94ba11f3d7dc60d260/without-webhooks/server/python/server.py#L65) sets the flag, whereas the Ruby appears to be missing it.