### PR TITLE
Fixed Uncaught IntegrationError in pay() function

### DIFF
--- a/using-webhooks/client/script.js
+++ b/using-webhooks/client/script.js
@@ -85,7 +85,7 @@ var pay = function(stripe, card, clientSecret) {
   // Use save_payment_method to indicate that you want to save the card
   // Use setup_future_usage to tell Stripe how you plan on charging the card
   stripe
-    .confirmCardPayment(clientSecret, card, {
+    .confirmCardPayment(clientSecret, {
       payment_method: data,
       setup_future_usage: isSavingCard ? "off_session" : ""
     })


### PR DESCRIPTION
I got below error when I try using-webhook sample.

```
(index):1 Uncaught IntegrationError: Do not pass an Element to stripe.confirmCardPayment() directly.
For more information: https://stripe.com/docs/stripe-js/reference#stripe-confirm-card-payment
    at new t (https://js.stripe.com/v3/:1:10762)
    at Ya (https://js.stripe.com/v3/:1:112407)
    at https://js.stripe.com/v3/:1:122918
    at https://js.stripe.com/v3/:1:35342
    at e.<anonymous> (https://js.stripe.com/v3/:1:143175)
    at e.confirmCardPayment (https://js.stripe.com/v3/:1:26438)
    at pay (http://localhost:4242/script.js:88:6)
at HTMLButtonElement.<anonymous> (http://localhost:4242/script.js:28:7)
```